### PR TITLE
fix: respect the env in which the daemon is executed

### DIFF
--- a/git-http-backend.go
+++ b/git-http-backend.go
@@ -131,7 +131,7 @@ func serviceRpc(hr HandlerReq) {
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(http.StatusOK)
 
-	env := []string{}
+	env := os.Environ()
 
 	if config.DefaultEnv != "" {
 		env = append(env, config.DefaultEnv)


### PR DESCRIPTION
This would go upstream but there is some other wire-protocol related work that expands the diff, so its best if this just lands here for now.

Refs plotly/streambed#13311